### PR TITLE
fix(specht-labs-v2): redirect HTTP to HTTPS for StaticPages hosts

### DIFF
--- a/kustomize/overlays/specht-labs-v2/static-pages/httproute.yaml
+++ b/kustomize/overlays/specht-labs-v2/static-pages/httproute.yaml
@@ -2,8 +2,10 @@
 #   pages.specht-labs.de/api -> static-pages-api:8081 (management API)
 #   every served host /       -> static-pages-proxy:8080 (page content)
 # Routes and backends share the static-pages namespace, so no ReferenceGrant is needed.
-# parentRefs omit sectionName, so each route binds to every shared-Gateway listener whose
-# hostname intersects its hostnames (the StaticPages Terminate listeners in gateway.yaml).
+# parentRefs pin port: 443 so the routes attach ONLY to the HTTPS Terminate listeners and
+# NOT the shared :80 http listener. Without this they bind to :80 too, where their specific
+# hostname beats the platform 301 redirect (redirect-httproute.yaml) and the sites get
+# served over plaintext HTTP instead of redirecting to HTTPS.
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -14,6 +16,7 @@ spec:
   parentRefs:
     - name: shared
       namespace: envoy-gateway-system
+      port: 443
   # /api is scoped to pages.specht-labs.de only (matches v1); on other hosts /api falls
   # through to the proxy route below.
   hostnames:
@@ -36,6 +39,7 @@ spec:
   parentRefs:
     - name: shared
       namespace: envoy-gateway-system
+      port: 443
   # Wildcards so one-level branch previews (e.g. branch.specht-labs.de) route to the proxy.
   # The more specific /api match on the api route wins for pages.specht-labs.de (path
   # precedence is evaluated across routes attached to the same Gateway).


### PR DESCRIPTION
## Goal

Make the StaticPages hosts on v2 (`specht-labs.de`, `pages.specht-labs.de`, `gold-specht.de`, and the rest) redirect plain HTTP to HTTPS instead of serving content over port 80.

## Background

After the v2 cutover (#1731) and the DNS switch, `curl https://specht-labs.de` briefly failed with `SSL_ERROR_SYSCALL`. That turned out to be transient: the `static-pages-tls` wildcard cert was still issuing (it went `Ready` at 14:14Z) so the `:443` listeners had no cert yet. Once issued, HTTPS works on all hosts (verified, valid Let's Encrypt cert).

While confirming that on the cluster I found a real bug: HTTP was not redirecting.

```
$ curl -4 -sS -o /dev/null -w "%{http_code} %{redirect_url}\n" http://specht-labs.de
200
```

The shared Gateway's `http` (:80) listener reported `attachedRoutes: 3`. The two StaticPages HTTPRoutes were attaching to `:80` in addition to the `:443` listeners, because their `parentRefs` set no port. On `:80` their specific hostname match beat the platform 301 redirect route (`redirect-httproute.yaml`), so the sites were served over plaintext HTTP.

## Fix

Pin `port: 443` on both routes' `parentRefs`. A parent ref with a port attaches only to listeners on that port, so the StaticPages routes now bind to the four HTTPS Terminate listeners and not to `:80`. The `:80` listener is left with just the platform redirect route, which 301s everything to HTTPS.

```yaml
parentRefs:
  - name: shared
    namespace: envoy-gateway-system
    port: 443
```

HTTPS routing is unchanged (the routes still attach to the same `:443` listeners by hostname intersection).

## Verification

`kustomize build` renders both routes with `port: 443`. Once ArgoCD syncs, the `http` listener should drop to `attachedRoutes: 1` and `curl http://specht-labs.de` should return a 301 to `https://`. The live patch test was intentionally not run against prod; this goes through GitOps.

Note: the TLS listeners also report a cosmetic `OverlappingTLSConfig=True` because all four share the one multi-SAN wildcard cert. HTTPS works correctly; left as-is.