### PR TITLE
perf(monitoring): trim Grafana Cloud metrics cost (Tier 1 + Tier 2)

### DIFF
--- a/kustomize/bases/grafana-k8s-monitoring/helm-values.yaml
+++ b/kustomize/bases/grafana-k8s-monitoring/helm-values.yaml
@@ -19,6 +19,44 @@ destinations:
         regex = "container_id|image_id"
         action = "labeldrop"
       }
+      // --- Cost control: drop leaf metrics nothing queries (Tier 1) ---
+      // Envoy proxy stats: ~4.5k series. Not a Knowledge Graph input; no
+      // dashboards/SLOs/alerts reference them.
+      write_relabel_config {
+        source_labels = ["__name__"]
+        regex = "envoy_.*"
+        action = "drop"
+      }
+      // hcloud-exporter: ~365 series, only ever manually explored.
+      write_relabel_config {
+        source_labels = ["__name__"]
+        regex = "hcloud_.*"
+        action = "drop"
+      }
+      // ArgoCD's own exporter metrics (workqueue/go/controller/rest_client
+      // histograms ~3.7k series): drop everything from the argocd.* jobs EXCEPT
+      // grpc_server_*, which the Knowledge Graph consumes for service RED.
+      // Scoped by `job` (NOT namespace) so kube-state/cAdvisor series ABOUT
+      // argocd workloads — which the K8s Monitoring app and KG entity model
+      // need — are left untouched. RE2 has no negative lookahead, so protect
+      // grpc_server_* with a temp keep-marker label, then drop the rest.
+      write_relabel_config {
+        source_labels = ["job", "__name__"]
+        separator = ";"
+        regex = "argocd.*;grpc_server.*"
+        target_label = "__tmp_keep_argocd"
+        replacement = "keep"
+      }
+      write_relabel_config {
+        source_labels = ["job", "__tmp_keep_argocd"]
+        separator = ";"
+        regex = "argocd.*;"
+        action = "drop"
+      }
+      write_relabel_config {
+        regex = "__tmp_keep_argocd"
+        action = "labeldrop"
+      }
   grafana-cloud-logs:
     type: loki
     url: https://logs-prod-012.grafana.net./loki/api/v1/push
@@ -106,7 +144,11 @@ applicationObservability:
       enabled: true
       port: 9411
 autoInstrumentation:
-  enabled: true # change me
+  # Tier 2 cost control: Beyla eBPF RED (~4.7k series) is largely redundant with
+  # span metrics from traces (applicationObservability stays enabled). Disabling
+  # loses eBPF RED + KG network-flow edges for services that emit no traces
+  # (e.g. nginx/static-pages). Re-enable if you miss RED on untraced workloads.
+  enabled: false
   collector: alloy-metrics
   beyla:
     deliverTracesToApplicationObservability: true


### PR DESCRIPTION
## Goal

Cut the Grafana Cloud metrics bill on specht-labs-v2 by dropping billable active series that no dashboard, SLO, alert, or Cloud feature actually consumes. Hold this until the trial ends, then merge.

Live usage put metrics at ~43.9k billable active series, which on Pro Pay-As-You-Go is ~$220/mo at $6.50/1k, roughly 80% of the whole bill. The driver is active series, not DPM, so scrape-interval tuning does nothing here (average is already ~0.95 DPM/series, under the 1-DPM threshold). The only lever that moves this bill is series count.

This PR is Tier 1 + Tier 2 of a three-tier plan. Together they remove ~13.2k series (~$86/mo), taking metrics from ~$220 to ~$134/mo with negligible loss. Tier 3 is documented below but intentionally not implemented (it's a Cloud-side toggle, and a judgement call).

## Rationale

Findings that scoped the cuts, all measured against the live instance:

- Only 1 custom dashboard and 0 SLOs exist, so the account relies on built-in Cloud apps (Kubernetes Monitoring, Entity Graph, App Observability), not hand-built views.
- The Knowledge Graph is alive (293 entities, 21 active insights) and is fueled by `spanmetrics_`, `beyla_network_flow_`, and `grpc_server_` (confirmed in KG's generated relabel keep-list). So those families are load-bearing and were deliberately preserved.
- App Observability / traces are in active use, so span metrics stay.
- `envoy_*`, `hcloud_*`, and ArgoCD's own exporter metrics are referenced by nothing and are not KG inputs.

## Changes

All in `kustomize/bases/grafana-k8s-monitoring/helm-values.yaml`.

### Tier 1: drop leaf metrics nothing queries (~8.5k series)

Added `write_relabel_config` drop rules to the `grafana-cloud-metrics` destination so the series are dropped before remote-write and never billed:

- `envoy_*` (~4.5k series)
- `hcloud_*` (~365 series)
- ArgoCD's own jobs (~3.7k series): workqueue / go runtime / controller-runtime / rest_client histograms

The ArgoCD rule keeps `grpc_server_*` because the Knowledge Graph consumes it for service RED. RE2 has no negative lookahead, so the "drop all argocd-job series except grpc_server" is done with a temporary keep-marker label:

```
write_relabel_config {
  source_labels = ["job", "__name__"]
  separator = ";"
  regex = "argocd.*;grpc_server.*"
  target_label = "__tmp_keep_argocd"
  replacement = "keep"
}
write_relabel_config {
  source_labels = ["job", "__tmp_keep_argocd"]
  separator = ";"
  regex = "argocd.*;"
  action = "drop"
}
```

The rule is scoped by `job=~"argocd.*"`, deliberately NOT by `namespace="argocd"`. Kube-state and cAdvisor series ABOUT argocd workloads carry `namespace="argocd"` but are needed by the K8s Monitoring app and the KG entity model. Scoping by job hits only ArgoCD's own exporters and leaves those untouched.

### Tier 2: disable Beyla auto-instrumentation (~4.7k series)

Set `autoInstrumentation.enabled: false`. Beyla's eBPF RED metrics are largely redundant with the span metrics already produced from traces (`applicationObservability` stays enabled). The known trade-off: services that emit no traces (nginx, static-pages) lose their RED metrics and their KG network-flow edges. Re-enable if that coverage is missed.

## Tier 3 (documented, NOT in this PR)

Disable Asserts / Knowledge Graph to reclaim the `asserts:*` recording rules (~6.9k series, ~$45/mo). This is a Grafana Cloud-side toggle, not a repo change, so it can't ride in this PR. It's also a judgement call: the Entity Graph is only occasionally used, and its topology view overlaps heavily with the App Observability service graph (which stays), so most of the value survives without it.

To apply Tier 3 when ready: disable the Knowledge Graph / Asserts in the Grafana Cloud UI. Doing so also retires the auto-generated `AssertsBase*` alert rules, which is expected. With Tier 1 + 2 + 3 the metrics bill lands around ~$89/mo (down from ~$220).

## Notes

Verified with `kustomize build --enable-helm`: the base renders clean, the Beyla feature is fully gone from the Alloy config, and all drop rules appear in the rendered remote_write blocks. The overlay itself needs the ksops plugin to render (SOPS secrets), so verification was done against the base.

Nothing here is destructive to historical data already in Cloud; it only stops future ingest of the dropped series once merged and synced by ArgoCD.
