### PR TITLE
feat(lgtm): self-hosted multi-tenant Mimir on specht-labs-v2 (hold for trial end)

### DIFF
--- a/argo-apps/specht-labs-v2/lgtm.yaml
+++ b/argo-apps/specht-labs-v2/lgtm.yaml
@@ -1,0 +1,46 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: lgtm
+  namespace: argocd
+spec:
+  generators:
+    - list:
+        elements:
+          - name: mimir
+            path: kustomize/overlays/specht-labs-v2/mimir
+            namespace: lgtm
+          # LGTM stack scaffold. Uncomment each as it is migrated; add the
+          # matching overlay under kustomize/overlays/specht-labs-v2/<name>.
+          # - name: loki
+          #   path: kustomize/overlays/specht-labs-v2/loki
+          #   namespace: lgtm
+          # - name: tempo
+          #   path: kustomize/overlays/specht-labs-v2/tempo
+          #   namespace: lgtm
+          # - name: grafana
+          #   path: kustomize/overlays/specht-labs-v2/grafana
+          #   namespace: lgtm
+  template:
+    metadata:
+      name: "{{name}}"
+      namespace: argocd
+      finalizers:
+        - resources-finalizer.argocd.argoproj.io
+    spec:
+      destination:
+        namespace: "{{namespace}}"
+        server: https://kubernetes.default.svc
+      project: default
+      source:
+        path: "{{path}}"
+        repoURL: https://github.com/SpechtLabs/k8s-deployment.git
+        targetRevision: main
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+          - SkipDryRunOnMissingResource=true

--- a/docs/superpowers/plans/2026-06-10-self-hosted-mimir-lgtm.md
+++ b/docs/superpowers/plans/2026-06-10-self-hosted-mimir-lgtm.md
@@ -1,0 +1,518 @@
+# Self-hosted Mimir (LGTM scaffold) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up a right-sized, multi-tenant Grafana Mimir (Kafka ingest-storage) on specht-labs-v2 in an `lgtm` namespace, ingesting via the existing tailnet Gateway, with the LGTM ApplicationSet scaffolded so Loki/Tempo/Grafana are a one-line add later.
+
+**Architecture:** `mimir-distributed` 6.0.6 (Mimir 3.0.4) via kustomize `helmCharts`, scaled to 1 replica per component, RF1, Kafka ingest-storage (single-node KRaft), blocks in Hetzner Object Storage. Deployed by an ArgoCD ApplicationSet that mirrors the repo's `monitoring`/`network` appsets. Three tenants (`homelab`, `hass`, `hass-schiltach`) tagged by per-hostname `X-Scope-OrgID` injection on HTTPRoutes.
+
+**Tech Stack:** Kustomize (+ `--enable-helm`), Helm chart `grafana/mimir-distributed` 6.0.6, ksops + SOPS/age, Gateway API (Envoy Gateway), ArgoCD ApplicationSet.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-10-self-hosted-mimir-lgtm-design.md`
+
+---
+
+## Prerequisites (the operator provides at execution time)
+
+1. A Hetzner Object Storage bucket (default name used here: `specht-labs-mimir-blocks`).
+2. The bucket region (`fsn1`, `nbg1`, or `hel1`) — sets the S3 `endpoint`.
+3. An access key + secret key for that bucket.
+4. Local tooling: `kustomize`, `helm`, `sops`. The age **public** recipients are already in `.sops.yaml`, so `sops -e` works without private keys; only ArgoCD (in-cluster) needs the private key to decrypt.
+
+If the bucket name or region differs, change the two values in `kustomize/bases/mimir/helm-values.yaml` (`bucket_name`, `endpoint`) before Task 1's verify step.
+
+## File structure
+
+```
+kustomize/bases/mimir/
+  kustomization.yaml          # helmCharts: mimir-distributed 6.0.6, releaseName mimir, valuesFile
+  helm-values.yaml            # right-sized values + mimir.structuredConfig
+kustomize/overlays/specht-labs-v2/mimir/
+  kustomization.yaml          # namespace lgtm; references base + httproutes; ksops generator
+  secret-generator.yaml       # ksops generator manifest
+  mimir-objstore.secret.yaml  # SOPS-encrypted Secret: AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+  httproutes.yaml             # 3 HTTPRoutes, per-tenant X-Scope-OrgID injection
+argo-apps/specht-labs-v2/lgtm.yaml   # ApplicationSet: mimir live, loki/tempo/grafana commented
+```
+
+Each file has one job: the base defines the workload, the overlay binds it to the cluster (namespace, secret, ingest), the appset tells ArgoCD to deploy it.
+
+---
+
+### Task 1: Mimir base (chart + values)
+
+**Files:**
+- Create: `kustomize/bases/mimir/kustomization.yaml`
+- Create: `kustomize/bases/mimir/helm-values.yaml`
+
+- [ ] **Step 1: Create the base kustomization**
+
+`kustomize/bases/mimir/kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: lgtm
+
+helmCharts:
+  - name: mimir-distributed
+    repo: https://grafana.github.io/helm-charts
+    version: 6.0.6
+    releaseName: mimir
+    namespace: lgtm
+    valuesFile: helm-values.yaml
+```
+
+- [ ] **Step 2: Create the right-sized values**
+
+`kustomize/bases/mimir/helm-values.yaml`:
+
+```yaml
+# Right-sized single-replica Mimir for homelab scale (Kafka ingest-storage).
+# Structural reference: grafana mimir-distributed/small.yaml, scaled to RF1 and
+# 1 replica each. Chart-default per-component resources are already modest
+# (ingester 100m/512Mi, not small.yaml's 3.5/8Gi), so resources are NOT overridden.
+
+minio:
+  enabled: false              # blocks live in Hetzner Object Storage, not bundled MinIO
+
+alertmanager:
+  enabled: false              # not needed for v1
+ruler:
+  enabled: false              # not needed for v1
+rollout_operator:
+  enabled: false              # only needed for zone-aware rollouts (which we disable)
+
+global:
+  extraEnvFrom:
+    - secretRef:
+        name: mimir-objstore  # provides AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+
+distributor:
+  replicas: 1
+querier:
+  replicas: 1
+query_frontend:
+  replicas: 1
+query_scheduler:
+  replicas: 1
+overrides_exporter:
+  replicas: 1
+
+ingester:
+  replicas: 1
+  zoneAwareReplication:
+    enabled: false
+  persistentVolume:
+    enabled: true
+    size: 10Gi
+
+store_gateway:
+  replicas: 1
+  zoneAwareReplication:
+    enabled: false
+  persistentVolume:
+    enabled: true
+    size: 5Gi
+
+compactor:
+  replicas: 1
+  persistentVolume:
+    enabled: true
+    size: 10Gi
+
+gateway:
+  replicas: 1
+
+# kafka stays enabled (chart default) for ingest-storage: single-node KRaft
+# (apache/kafka-native, no Zookeeper). Chart defaults: 5Gi PV, 1 CPU / 1Gi. Left as-is.
+
+mimir:
+  structuredConfig:
+    multitenancy_enabled: true
+    common:
+      storage:
+        backend: s3
+        s3:
+          # CHANGE to your Hetzner Object Storage region: fsn1 / nbg1 / hel1
+          endpoint: fsn1.your-objectstorage.com
+          bucket_name: specht-labs-mimir-blocks
+          access_key_id: ${AWS_ACCESS_KEY_ID}
+          secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+    ingester:
+      ring:
+        replication_factor: 1
+    store_gateway:
+      sharding_ring:
+        replication_factor: 1
+    ingest_storage:
+      kafka:
+        auto_create_topic_default_partitions: 8
+```
+
+- [ ] **Step 3: Render and assert the topology**
+
+Run:
+```bash
+kustomize build --enable-helm kustomize/bases/mimir > /tmp/mimir-base.yaml && echo OK
+```
+Expected: prints `OK` (exit 0), no errors.
+
+Then assert the invariants:
+```bash
+grep -c 'multitenancy_enabled: true'                 /tmp/mimir-base.yaml   # -> 1
+grep -c 'replication_factor: 1'                       /tmp/mimir-base.yaml   # -> 2 (ingester + store_gateway)
+grep -c 'auto_create_topic_default_partitions: 8'     /tmp/mimir-base.yaml   # -> 1
+grep -c 'name: mimir-kafka'                            /tmp/mimir-base.yaml   # -> >=1 (kafka present)
+grep -c 'name: mimir-alertmanager'                    /tmp/mimir-base.yaml   # -> 0
+grep -c 'name: mimir-ruler'                           /tmp/mimir-base.yaml   # -> 0
+grep -Ec 'kind: .*[Mm]inio'                           /tmp/mimir-base.yaml   # -> 0
+grep -c 'config.expand-env=true'                      /tmp/mimir-base.yaml   # -> >=10 (env expansion on)
+```
+Expected: the counts in the comments. If `mimir-alertmanager`/`mimir-ruler`/minio are non-zero, the disable toggles did not apply — recheck Step 2.
+
+- [ ] **Step 4: Confirm every workload is namespaced to lgtm**
+
+Run:
+```bash
+grep -E '^\s+namespace:' /tmp/mimir-base.yaml | grep -v 'lgtm' || echo "all lgtm"
+```
+Expected: `all lgtm` (the base `namespace: lgtm` rewrites everything).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add kustomize/bases/mimir/
+git commit -m "feat(lgtm): add right-sized Mimir base (mimir-distributed 6.0.6, Kafka ingest-storage)"
+```
+
+---
+
+### Task 2: specht-labs-v2 overlay (namespace, S3 secret, ingest routes)
+
+**Files:**
+- Create: `kustomize/overlays/specht-labs-v2/mimir/secret-generator.yaml`
+- Create: `kustomize/overlays/specht-labs-v2/mimir/mimir-objstore.secret.yaml`
+- Create: `kustomize/overlays/specht-labs-v2/mimir/httproutes.yaml`
+- Create: `kustomize/overlays/specht-labs-v2/mimir/kustomization.yaml`
+
+- [ ] **Step 1: Create the ksops generator**
+
+`kustomize/overlays/specht-labs-v2/mimir/secret-generator.yaml`:
+
+```yaml
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: mimir-objstore-secrets
+files:
+  - ./mimir-objstore.secret.yaml
+```
+
+- [ ] **Step 2: Create the object-storage Secret (plaintext, will be encrypted next)**
+
+`kustomize/overlays/specht-labs-v2/mimir/mimir-objstore.secret.yaml`. Replace the two values with the real Hetzner keys from the prerequisites:
+
+```yaml
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: mimir-objstore
+  namespace: lgtm
+stringData:
+  AWS_ACCESS_KEY_ID: REPLACE_WITH_HETZNER_ACCESS_KEY
+  AWS_SECRET_ACCESS_KEY: REPLACE_WITH_HETZNER_SECRET_KEY
+```
+
+- [ ] **Step 3: Encrypt the Secret in place with SOPS**
+
+Run:
+```bash
+sops -e -i kustomize/overlays/specht-labs-v2/mimir/mimir-objstore.secret.yaml
+```
+Then verify it is encrypted (no plaintext key material remains):
+```bash
+grep -c 'ENC\[' kustomize/overlays/specht-labs-v2/mimir/mimir-objstore.secret.yaml   # -> >=2
+grep -c 'REPLACE_WITH_'    kustomize/overlays/specht-labs-v2/mimir/mimir-objstore.secret.yaml   # -> 0
+grep -c 'sops:'            kustomize/overlays/specht-labs-v2/mimir/mimir-objstore.secret.yaml   # -> 1
+```
+Expected: the `stringData` values are now `ENC[AES256_GCM,...]`, no `REPLACE_WITH_` left, a `sops:` block present. The `.sops.yaml` rule `kustomize/.*/.*secret.yaml` encrypts `stringData` automatically; `metadata.name`/`namespace` stay readable.
+
+- [ ] **Step 4: Create the per-tenant ingest routes**
+
+`kustomize/overlays/specht-labs-v2/mimir/httproutes.yaml`:
+
+```yaml
+# One HTTPRoute per tenant on the tailnet-only Gateway. Each injects the tenant's
+# X-Scope-OrgID so clients (Pis, Home Assistant) need no custom-header config.
+# Route + backend (mimir-gateway) are both in lgtm, so no ReferenceGrant needed.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mimir-homelab
+  namespace: lgtm
+spec:
+  parentRefs:
+    - name: tailnet
+      namespace: envoy-gateway-system
+      sectionName: http
+  hostnames:
+    - homelab.mimir.k8s.specht-labs.de
+  rules:
+    - filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Scope-OrgID
+                value: homelab
+      backendRefs:
+        - name: mimir-gateway
+          port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mimir-hass
+  namespace: lgtm
+spec:
+  parentRefs:
+    - name: tailnet
+      namespace: envoy-gateway-system
+      sectionName: http
+  hostnames:
+    - hass.mimir.k8s.specht-labs.de
+  rules:
+    - filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Scope-OrgID
+                value: hass
+      backendRefs:
+        - name: mimir-gateway
+          port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mimir-hass-schiltach
+  namespace: lgtm
+spec:
+  parentRefs:
+    - name: tailnet
+      namespace: envoy-gateway-system
+      sectionName: http
+  hostnames:
+    - hass-schiltach.mimir.k8s.specht-labs.de
+  rules:
+    - filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Scope-OrgID
+                value: hass-schiltach
+      backendRefs:
+        - name: mimir-gateway
+          port: 80
+```
+
+- [ ] **Step 5: Create the overlay kustomization**
+
+`kustomize/overlays/specht-labs-v2/mimir/kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: lgtm
+
+resources:
+  - ../../../bases/mimir
+  - ./httproutes.yaml
+
+generators:
+  - ./secret-generator.yaml
+```
+
+- [ ] **Step 6: Validate the route + secret YAML (portable, no ksops needed)**
+
+The full overlay build needs the ksops exec plugin and the age private key, which only ArgoCD has. Validate the hand-written manifests instead:
+
+Run:
+```bash
+kubeconform -strict -ignore-missing-schemas kustomize/overlays/specht-labs-v2/mimir/httproutes.yaml && echo ROUTES_OK
+```
+Expected: `ROUTES_OK`. If `kubeconform` is not installed, fall back to:
+```bash
+python3 -c "import yaml,sys; list(yaml.safe_load_all(open('kustomize/overlays/specht-labs-v2/mimir/httproutes.yaml'))); print('YAML_OK')"
+```
+Expected: `YAML_OK` and three documents parse.
+
+Assert the tenant wiring:
+```bash
+grep -c 'X-Scope-OrgID'   kustomize/overlays/specht-labs-v2/mimir/httproutes.yaml   # -> 3
+grep -c 'value: homelab\|value: hass\|value: hass-schiltach' kustomize/overlays/specht-labs-v2/mimir/httproutes.yaml   # -> 3
+grep -c 'name: mimir-gateway' kustomize/overlays/specht-labs-v2/mimir/httproutes.yaml   # -> 3
+```
+Expected: 3, 3, 3.
+
+- [ ] **Step 7: (Optional) Full overlay build if ksops + age key are available locally**
+
+Only if the executor has KSOPS installed and the age private key in `SOPS_AGE_KEY_FILE`:
+```bash
+kustomize build --enable-helm --enable-alpha-plugins --enable-exec \
+  kustomize/overlays/specht-labs-v2/mimir > /tmp/mimir-overlay.yaml && \
+  grep -c 'kind: HTTPRoute' /tmp/mimir-overlay.yaml   # -> 3
+```
+Expected: builds clean, 3 HTTPRoutes. If ksops/age is not available, skip — ArgoCD performs this build in-cluster.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add kustomize/overlays/specht-labs-v2/mimir/
+git commit -m "feat(lgtm): mimir overlay for specht-labs-v2 (lgtm ns, Hetzner S3 secret, per-tenant ingest routes)"
+```
+
+---
+
+### Task 3: LGTM ApplicationSet
+
+**Files:**
+- Create: `argo-apps/specht-labs-v2/lgtm.yaml`
+
+- [ ] **Step 1: Create the ApplicationSet**
+
+`argo-apps/specht-labs-v2/lgtm.yaml`:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: lgtm
+  namespace: argocd
+spec:
+  generators:
+    - list:
+        elements:
+          - name: mimir
+            path: kustomize/overlays/specht-labs-v2/mimir
+            namespace: lgtm
+          # LGTM stack scaffold. Uncomment each as it is migrated; add the
+          # matching overlay under kustomize/overlays/specht-labs-v2/<name>.
+          # - name: loki
+          #   path: kustomize/overlays/specht-labs-v2/loki
+          #   namespace: lgtm
+          # - name: tempo
+          #   path: kustomize/overlays/specht-labs-v2/tempo
+          #   namespace: lgtm
+          # - name: grafana
+          #   path: kustomize/overlays/specht-labs-v2/grafana
+          #   namespace: lgtm
+  template:
+    metadata:
+      name: "{{name}}"
+      namespace: argocd
+      finalizers:
+        - resources-finalizer.argocd.argoproj.io
+    spec:
+      destination:
+        namespace: "{{namespace}}"
+        server: https://kubernetes.default.svc
+      project: default
+      source:
+        path: "{{path}}"
+        repoURL: https://github.com/SpechtLabs/k8s-deployment.git
+        targetRevision: main
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+          - SkipDryRunOnMissingResource=true
+```
+
+- [ ] **Step 2: Validate the ApplicationSet YAML**
+
+Run:
+```bash
+python3 -c "import yaml; d=yaml.safe_load(open('argo-apps/specht-labs-v2/lgtm.yaml')); assert d['kind']=='ApplicationSet'; els=d['spec']['generators'][0]['list']['elements']; assert [e['name'] for e in els]==['mimir'], els; print('APPSET_OK: only mimir active')"
+```
+Expected: `APPSET_OK: only mimir active` (the loki/tempo/grafana entries are comments, so the live element list is `['mimir']`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add argo-apps/specht-labs-v2/lgtm.yaml
+git commit -m "feat(lgtm): ApplicationSet scaffold (mimir live, loki/tempo/grafana stubbed)"
+```
+
+---
+
+### Task 4: Final verification and PR
+
+**Files:** none (verification + PR only)
+
+- [ ] **Step 1: Re-render the base one more time from a clean state**
+
+Run:
+```bash
+rm -rf kustomize/bases/mimir/charts 2>/dev/null; \
+kustomize build --enable-helm kustomize/bases/mimir > /tmp/mimir-final.yaml && \
+echo "workloads:" && awk '/^kind: (Deployment|StatefulSet)/{k=$2} /^  name: mimir-/{print k": "$2}' /tmp/mimir-final.yaml | sort -u | grep -viE 'headless|smoke|config|runtime|gossip|nginx'
+```
+Expected: 10 workloads — Deployments (distributor, gateway, overrides-exporter, querier, query-frontend, query-scheduler) and StatefulSets (compactor, ingester, kafka, store-gateway).
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin HEAD
+```
+
+- [ ] **Step 3: Open the PR (do NOT merge — hold until the Grafana Cloud trial ends)**
+
+Use the pull-request skill, or:
+```bash
+gh pr create --base main --title "feat(lgtm): self-hosted multi-tenant Mimir on specht-labs-v2" --body-file - <<'EOF'
+Stands up a right-sized Mimir (mimir-distributed 6.0.6, Kafka ingest-storage) in
+an lgtm namespace so the Pi homelab and Home Assistant instances can remote-write
+to durable Hetzner Object Storage instead of Grafana Cloud.
+
+Tenants (X-Scope-OrgID injected per hostname on the tailnet Gateway):
+- homelab            -> homelab.mimir.k8s.specht-labs.de
+- hass               -> hass.mimir.k8s.specht-labs.de
+- hass-schiltach     -> hass-schiltach.mimir.k8s.specht-labs.de
+
+Only Mimir is live; the LGTM ApplicationSet has Loki/Tempo/Grafana stubbed.
+
+Design: docs/superpowers/specs/2026-06-10-self-hosted-mimir-lgtm-design.md
+
+Note: capacity is tight on the 3x cx23 workers (~11.7Gi total); Mimir+Kafka add
+~1.8 vCPU / 3.6Gi of requests. Watch scheduling after first sync.
+EOF
+```
+
+- [ ] **Step 4: Post-merge verification (run only after the PR is merged and ArgoCD syncs)**
+
+```bash
+export KUBECONFIG=~/.kube/configs/specht-labs
+kubectl -n lgtm get pods                       # all Running/Ready
+kubectl -n lgtm get pvc                        # ingester/store-gateway/compactor/kafka Bound
+kubectl -n lgtm rollout status statefulset/mimir-ingester
+# Tenant isolation smoke test (from a tailnet host):
+#   write a sample to http://homelab.mimir.k8s.specht-labs.de/api/v1/push
+#   query it back with X-Scope-OrgID: homelab  -> returns the sample
+#   query it back with X-Scope-OrgID: hass      -> returns nothing
+```
+Expected: pods Ready, PVCs Bound, the sample visible only under its own tenant.
+
+---
+
+## Notes / risks
+
+- Capacity: 3x cx23 workers (2 vCPU / ~3.9 Gi each) shared with argocd/envoy/cilium/alloy. Mimir+Kafka requests ~1.8 vCPU / 3.6 Gi. It fits but is tight; if pods stay Pending, the cheapest fix is one larger worker in a dedicated pool, or trimming Kafka's 1 CPU / 1Gi request.
+- Single-node Kafka and RF1 ingester = no HA (matches the homelab posture). Kafka buffering means a restarting ingester replays rather than losing the unflushed window.
+- Trust model: Mimir does not authenticate `X-Scope-OrgID`; isolation rests on the tailnet-only LB plus the Gateway being the only header-setting path. Per-tenant auth is a later add (see spec security section).
+- The external write path depends on external-dns publishing `*.mimir.k8s.specht-labs.de` at the tailscale target; confirm the three hostnames resolve after sync.
+```

--- a/docs/superpowers/plans/2026-06-10-self-hosted-mimir-lgtm.md
+++ b/docs/superpowers/plans/2026-06-10-self-hosted-mimir-lgtm.md
@@ -258,7 +258,7 @@ spec:
       namespace: envoy-gateway-system
       sectionName: http
   hostnames:
-    - homelab.mimir.k8s.specht-labs.de
+    - homelab-mimir.k8s.specht-labs.de
   rules:
     - filters:
         - type: RequestHeaderModifier
@@ -281,7 +281,7 @@ spec:
       namespace: envoy-gateway-system
       sectionName: http
   hostnames:
-    - hass.mimir.k8s.specht-labs.de
+    - hass-mimir.k8s.specht-labs.de
   rules:
     - filters:
         - type: RequestHeaderModifier
@@ -304,7 +304,7 @@ spec:
       namespace: envoy-gateway-system
       sectionName: http
   hostnames:
-    - hass-schiltach.mimir.k8s.specht-labs.de
+    - hass-schiltach-mimir.k8s.specht-labs.de
   rules:
     - filters:
         - type: RequestHeaderModifier
@@ -480,9 +480,9 @@ an lgtm namespace so the Pi homelab and Home Assistant instances can remote-writ
 to durable Hetzner Object Storage instead of Grafana Cloud.
 
 Tenants (X-Scope-OrgID injected per hostname on the tailnet Gateway):
-- homelab            -> homelab.mimir.k8s.specht-labs.de
-- hass               -> hass.mimir.k8s.specht-labs.de
-- hass-schiltach     -> hass-schiltach.mimir.k8s.specht-labs.de
+- homelab            -> homelab-mimir.k8s.specht-labs.de
+- hass               -> hass-mimir.k8s.specht-labs.de
+- hass-schiltach     -> hass-schiltach-mimir.k8s.specht-labs.de
 
 Only Mimir is live; the LGTM ApplicationSet has Loki/Tempo/Grafana stubbed.
 
@@ -501,7 +501,7 @@ kubectl -n lgtm get pods                       # all Running/Ready
 kubectl -n lgtm get pvc                        # ingester/store-gateway/compactor/kafka Bound
 kubectl -n lgtm rollout status statefulset/mimir-ingester
 # Tenant isolation smoke test (from a tailnet host):
-#   write a sample to http://homelab.mimir.k8s.specht-labs.de/api/v1/push
+#   write a sample to http://homelab-mimir.k8s.specht-labs.de/api/v1/push
 #   query it back with X-Scope-OrgID: homelab  -> returns the sample
 #   query it back with X-Scope-OrgID: hass      -> returns nothing
 ```

--- a/docs/superpowers/specs/2026-06-10-self-hosted-mimir-lgtm-design.md
+++ b/docs/superpowers/specs/2026-06-10-self-hosted-mimir-lgtm-design.md
@@ -1,0 +1,166 @@
+# Self-hosted Mimir (LGTM scaffold) on specht-labs-v2
+
+Date: 2026-06-10
+Status: Approved (design), pending implementation plan
+
+## Goal
+
+Run a self-hosted Grafana Mimir on the specht-labs-v2 cloud cluster so the
+Raspberry Pi homelab can remote-write metrics into durable, in-cloud storage
+without running a TSDB on the Pis and without sending the data to Grafana Cloud
+hosted Mimir.
+
+This round migrates **only Mimir**, but lands the **LGTM ApplicationSet
+scaffold** (Loki / Grafana / Tempo / Mimir) so the other three are a one-line
+uncomment later. Everything deploys into the `lgtm` namespace.
+
+## Scope
+
+In scope:
+- Mimir (right-sized distributed topology) deployed via the `mimir-distributed`
+  Helm chart, pinned.
+- Hetzner Object Storage (S3-compatible) for blocks.
+- SOPS-encrypted S3 credentials.
+- In-cluster Service plus one per-tenant HTTPRoute on the existing tailnet
+  Gateway as the remote-write ingest path (header-injected `X-Scope-OrgID`).
+- `lgtm` ApplicationSet with Mimir active and Loki/Tempo/Grafana stubbed.
+
+Out of scope (later rounds):
+- Loki / Tempo / Grafana deployment.
+- Mimir ruler and alertmanager.
+- Memcached caches.
+- Dashboards and recording/alerting rules.
+- Migrating any specht-labs-v2 self-metrics into this Mimir (separate decision;
+  the cost PR drops those rather than offloading them).
+
+## Decisions (from brainstorming)
+
+| Question | Decision |
+|----------|----------|
+| Sizing | Right-sized distributed: same microservices topology as `small.yaml`, 1 replica each, `replication_factor: 1`, small resource requests, caches off. |
+| Object storage | Hetzner Object Storage (S3), one bucket. Blocks off-cluster so they survive cluster rebuilds. |
+| Write path | One HTTPRoute per tenant on the existing tailnet-only Envoy Gateway (`tailnet`/`http`). Plain HTTP, private over WireGuard. Each route injects the tenant's `X-Scope-OrgID` header. |
+| Multitenancy | Enabled. Tenants created implicitly on first write. Tenant tagging done by the Gateway (per-hostname header injection), so clients need no custom-header config. |
+| Reference config | Grafana's `mimir-distributed/small.yaml` used as the structural reference only; our sizing/storage applied via `mimir.structuredConfig`. |
+
+## Architecture
+
+### Repo layout
+
+```
+argo-apps/specht-labs-v2/lgtm.yaml              # ApplicationSet; mimir active, loki/tempo/grafana commented
+kustomize/bases/mimir/
+  kustomization.yaml                             # helmCharts: mimir-distributed (pinned) + valuesFile
+  helm-values.yaml                               # right-sized values + structuredConfig
+kustomize/overlays/specht-labs-v2/mimir/
+  kustomization.yaml                             # namespace: lgtm; references base; SOPS generator
+  secret-generator.yaml                          # ksops generator
+  mimir-objstore.secret.yaml                     # SOPS-encrypted Hetzner S3 access/secret keys
+  httproutes.yaml                                # one HTTPRoute per tenant (X-Scope-OrgID injection)
+```
+
+This mirrors the existing base/overlay split (see `grafana-k8s-monitoring`) and
+the AppSet conventions in `monitoring.yaml` / `network.yaml`.
+
+### Mimir topology (1 replica each)
+
+Enabled: distributor, ingester, querier, query-frontend, store-gateway,
+compactor, and the chart's front proxy (nginx/gateway) as the read/write Service.
+
+Disabled for v1: alertmanager, ruler, chunks/index/metadata/results caches,
+bundled MinIO.
+
+`structuredConfig` highlights:
+- `multitenancy_enabled: true`
+- `ingester.ring.replication_factor: 1`
+- `blocks_storage.backend: s3` + `blocks_storage.s3` pointing at Hetzner
+  (`endpoint: <region>.your-objectstorage.com`, `bucket_name`,
+  `force_path_style: true` if required by Hetzner).
+- Credentials via env expansion: `access_key_id: ${AWS_ACCESS_KEY_ID}`,
+  `secret_access_key: ${AWS_SECRET_ACCESS_KEY}`, with `-config.expand-env=true`.
+
+Rough footprint: ~7 pods, ~4-6 GB RAM.
+
+### Storage
+
+- Blocks: Hetzner Object Storage bucket (e.g. `specht-labs-mimir-blocks`).
+- Local working set via hcloud-csi PVCs: ingester ~10Gi, store-gateway ~5Gi,
+  compactor ~10Gi (tunable).
+
+### Secrets
+
+S3 access key + secret key in a SOPS-encrypted Secret (ksops generator, same
+pattern as other overlays). Injected into Mimir pods as `AWS_ACCESS_KEY_ID` /
+`AWS_SECRET_ACCESS_KEY` env (chart `global.extraEnvFrom` or equivalent),
+referenced from `structuredConfig` via env expansion. No plaintext creds in
+values or git.
+
+### Tenants
+
+Multitenancy is enabled. Tenants are not pre-declared; Mimir creates them on
+first write. Initial tenant IDs:
+
+| Tenant ID | Source | Ingest hostname |
+|-----------|--------|-----------------|
+| `homelab` | Raspberry Pi homelab | `homelab.mimir.k8s.specht-labs.de` |
+| `hass` | My Home Assistant | `hass.mimir.k8s.specht-labs.de` |
+| `hass-schiltach` | Dad's Home Assistant (Schiltach) | `hass-schiltach.mimir.k8s.specht-labs.de` |
+
+Per-tenant limits (ingestion rate, max series, retention) are available via
+Mimir's runtime `overrides` config but are left at defaults for v1.
+
+### Ingest path
+
+One `HTTPRoute` per tenant in `lgtm`, all attached to the same Gateway:
+- `parentRefs`: `tailnet` / `envoy-gateway-system` / sectionName `http`.
+- `hostnames`: the per-tenant hostname from the table above (external-dns
+  publishes `*.k8s` at the tailscale target).
+- `filters`: `RequestHeaderModifier` that **sets** `X-Scope-OrgID` to the
+  tenant ID. This is why clients need no custom-header config.
+- `backendRefs`: Mimir front-proxy Service, HTTP port.
+
+Routes and backend are all in `lgtm`, so no ReferenceGrant. The `http` listener
+allows routes from all namespaces. A source remote-writes to
+`http://<tenant-host>/api/v1/push`; the Gateway stamps the tenant header.
+
+Security model: Mimir trusts the `X-Scope-OrgID` header and does no auth on it.
+Isolation rests on (a) the LB being tailnet-only and (b) the Gateway being the
+only path that sets the header. A malicious actor already on the tailnet could
+still spoof a tenant by calling the Service directly; acceptable for this
+homelab. Per-tenant tokens/auth can be added in front later if isolation needs
+to be stronger (e.g. before exposing dad's HA more widely).
+
+### LGTM ApplicationSet
+
+`lgtm.yaml` ApplicationSet, same template as `monitoring`/`network`:
+- generator list element **mimir** -> `kustomize/overlays/specht-labs-v2/mimir`,
+  namespace `lgtm`.
+- **loki / tempo / grafana** present as commented-out list elements.
+- `syncPolicy.automated` (prune + selfHeal), `CreateNamespace=true`,
+  `ServerSideApply=true`, `SkipDryRunOnMissingResource=true`.
+
+## Prerequisites (user actions)
+
+1. Create a Hetzner Object Storage bucket and an access key / secret key pair.
+2. Provide them so they can be SOPS-encrypted into `mimir-objstore.secret.yaml`.
+3. Confirm the bucket region for the S3 endpoint.
+
+## Verification
+
+- `kustomize build --enable-helm kustomize/bases/mimir` renders clean.
+- Rendered config shows `multitenancy_enabled: true`, `replication_factor: 1`,
+  and the Hetzner S3 endpoint.
+- Post-sync: Mimir pods Ready, `/ready` green.
+- A test write to `http://homelab.mimir.k8s.specht-labs.de/api/v1/push` returns
+  200, and a query for that sample with `X-Scope-OrgID: homelab` returns it,
+  while the same query under another tenant returns nothing (isolation holds).
+
+## Risks / notes
+
+- Single ingester + RF1 means no metrics HA: an ingester restart can lose the
+  most recent unflushed window. Acceptable for homelab; scale ingesters + RF
+  to 3 later if needed.
+- Mimir lives on the cluster it may also monitor; for pure homelab-Pi metrics
+  this is fine (the source is off-cluster).
+- Exact chart value keys (front proxy component name, env injection field) are
+  resolved against the pinned chart version during implementation.

--- a/docs/superpowers/specs/2026-06-10-self-hosted-mimir-lgtm-design.md
+++ b/docs/superpowers/specs/2026-06-10-self-hosted-mimir-lgtm-design.md
@@ -111,9 +111,9 @@ first write. Initial tenant IDs:
 
 | Tenant ID | Source | Ingest hostname |
 |-----------|--------|-----------------|
-| `homelab` | Raspberry Pi homelab | `homelab.mimir.k8s.specht-labs.de` |
-| `hass` | My Home Assistant | `hass.mimir.k8s.specht-labs.de` |
-| `hass-schiltach` | Dad's Home Assistant (Schiltach) | `hass-schiltach.mimir.k8s.specht-labs.de` |
+| `homelab` | Raspberry Pi homelab | `homelab-mimir.k8s.specht-labs.de` |
+| `hass` | My Home Assistant | `hass-mimir.k8s.specht-labs.de` |
+| `hass-schiltach` | Dad's Home Assistant (Schiltach) | `hass-schiltach-mimir.k8s.specht-labs.de` |
 
 Per-tenant limits (ingestion rate, max series, retention) are available via
 Mimir's runtime `overrides` config but are left at defaults for v1.
@@ -160,7 +160,7 @@ to be stronger (e.g. before exposing dad's HA more widely).
 - Rendered config shows `multitenancy_enabled: true`, `replication_factor: 1`,
   and the Hetzner S3 endpoint.
 - Post-sync: Mimir pods Ready, `/ready` green.
-- A test write to `http://homelab.mimir.k8s.specht-labs.de/api/v1/push` returns
+- A test write to `http://homelab-mimir.k8s.specht-labs.de/api/v1/push` returns
   200, and a query for that sample with `X-Scope-OrgID: homelab` returns it,
   while the same query under another tenant returns nothing (isolation holds).
 

--- a/docs/superpowers/specs/2026-06-10-self-hosted-mimir-lgtm-design.md
+++ b/docs/superpowers/specs/2026-06-10-self-hosted-mimir-lgtm-design.md
@@ -38,6 +38,8 @@ Out of scope (later rounds):
 | Question | Decision |
 |----------|----------|
 | Sizing | Right-sized distributed: same microservices topology as `small.yaml`, 1 replica each, `replication_factor: 1`, small resource requests, caches off. |
+| Architecture | Kafka ingest-storage (chart 6.0.6 / Mimir 3.0 default): distributor -> Kafka -> ingester. The chart bundles a single-node KRaft Kafka (`apache/kafka-native`, no Zookeeper). Topic partitions trimmed from the demo default of 100 to 8. |
+| Chart version | `mimir-distributed` 6.0.6 (Mimir 3.0.4), pinned. |
 | Object storage | Hetzner Object Storage (S3), one bucket. Blocks off-cluster so they survive cluster rebuilds. |
 | Write path | One HTTPRoute per tenant on the existing tailnet-only Envoy Gateway (`tailnet`/`http`). Plain HTTP, private over WireGuard. Each route injects the tenant's `X-Scope-OrgID` header. |
 | Multitenancy | Enabled. Tenants created implicitly on first write. Tenant tagging done by the Gateway (per-hostname header injection), so clients need no custom-header config. |
@@ -64,28 +66,35 @@ the AppSet conventions in `monitoring.yaml` / `network.yaml`.
 
 ### Mimir topology (1 replica each)
 
-Enabled: distributor, ingester, querier, query-frontend, store-gateway,
-compactor, and the chart's front proxy (nginx/gateway) as the read/write Service.
+Enabled (replicas: 1): distributor, ingester, querier, query-frontend,
+query-scheduler, store-gateway, compactor, overrides-exporter, the front proxy
+(`gateway`, nginx), and the bundled single-node `kafka` (ingest-storage).
 
-Disabled for v1: alertmanager, ruler, chunks/index/metadata/results caches,
-bundled MinIO.
+Disabled for v1: alertmanager, ruler, `rollout_operator` (only needed for
+zone-aware rollouts), chunks/index/metadata/results caches (already off by
+default), bundled MinIO.
 
 `structuredConfig` highlights:
 - `multitenancy_enabled: true`
-- `ingester.ring.replication_factor: 1`
-- `blocks_storage.backend: s3` + `blocks_storage.s3` pointing at Hetzner
-  (`endpoint: <region>.your-objectstorage.com`, `bucket_name`,
-  `force_path_style: true` if required by Hetzner).
+- `ingester.ring.replication_factor: 1` and
+  `store_gateway.sharding_ring.replication_factor: 1`
+- `ingest_storage.kafka.auto_create_topic_default_partitions: 8` (down from 100)
+- Object storage via `common.storage.backend: s3` + `common.storage.s3`
+  pointing at Hetzner (`endpoint: <region>.your-objectstorage.com`,
+  `bucket_name`).
 - Credentials via env expansion: `access_key_id: ${AWS_ACCESS_KEY_ID}`,
-  `secret_access_key: ${AWS_SECRET_ACCESS_KEY}`, with `-config.expand-env=true`.
+  `secret_access_key: ${AWS_SECRET_ACCESS_KEY}`. The chart already sets
+  `-config.expand-env=true` on every component.
 
-Rough footprint: ~7 pods, ~4-6 GB RAM.
+Footprint: ~10 pods. `zoneAwareReplication` disabled on ingester and
+store-gateway (single zone, RF1).
 
 ### Storage
 
 - Blocks: Hetzner Object Storage bucket (e.g. `specht-labs-mimir-blocks`).
-- Local working set via hcloud-csi PVCs: ingester ~10Gi, store-gateway ~5Gi,
-  compactor ~10Gi (tunable).
+- Local working set via hcloud-csi PVCs (default StorageClass `hcloud-volumes`):
+  ingester ~10Gi, store-gateway ~5Gi, compactor ~10Gi, kafka 5Gi (chart
+  default). All tunable.
 
 ### Secrets
 
@@ -158,8 +167,12 @@ to be stronger (e.g. before exposing dad's HA more widely).
 ## Risks / notes
 
 - Single ingester + RF1 means no metrics HA: an ingester restart can lose the
-  most recent unflushed window. Acceptable for homelab; scale ingesters + RF
-  to 3 later if needed.
+  most recent unflushed window. With ingest-storage, Kafka buffers the write so
+  a restarting ingester replays from the topic, which softens this. Scale
+  ingesters + RF to 3 later if needed.
+- Single-node Kafka is a SPOF: if it's down, writes stop (ingesters consume
+  from it). Consistent with the non-HA homelab posture; revisit if uptime
+  matters more later.
 - Mimir lives on the cluster it may also monitor; for pure homelab-Pi metrics
   this is fine (the source is off-cluster).
 - Exact chart value keys (front proxy component name, env injection field) are

--- a/kustomize/bases/mimir/helm-values.yaml
+++ b/kustomize/bases/mimir/helm-values.yaml
@@ -1,0 +1,80 @@
+# Right-sized single-replica Mimir for homelab scale (Kafka ingest-storage).
+# Structural reference: grafana mimir-distributed/small.yaml, scaled to RF1 and
+# 1 replica each. Chart-default per-component resources are already modest
+# (ingester 100m/512Mi, not small.yaml's 3.5/8Gi), so resources are NOT overridden.
+
+minio:
+  enabled: false              # blocks live in Hetzner Object Storage, not bundled MinIO
+
+alertmanager:
+  enabled: false              # not needed for v1
+ruler:
+  enabled: false              # not needed for v1
+rollout_operator:
+  enabled: false              # only needed for zone-aware rollouts (which we disable)
+
+global:
+  extraEnvFrom:
+    - secretRef:
+        name: mimir-objstore  # provides AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+
+distributor:
+  replicas: 1
+querier:
+  replicas: 1
+query_frontend:
+  replicas: 1
+query_scheduler:
+  replicas: 1
+overrides_exporter:
+  replicas: 1
+
+ingester:
+  replicas: 1
+  zoneAwareReplication:
+    enabled: false
+  persistentVolume:
+    enabled: true
+    size: 10Gi
+
+store_gateway:
+  replicas: 1
+  zoneAwareReplication:
+    enabled: false
+  persistentVolume:
+    enabled: true
+    size: 5Gi
+
+compactor:
+  replicas: 1
+  persistentVolume:
+    enabled: true
+    size: 10Gi
+
+gateway:
+  replicas: 1
+
+# kafka stays enabled (chart default) for ingest-storage: single-node KRaft
+# (apache/kafka-native, no Zookeeper). Chart defaults: 5Gi PV, 1 CPU / 1Gi. Left as-is.
+
+mimir:
+  structuredConfig:
+    multitenancy_enabled: true
+    common:
+      storage:
+        backend: s3
+        s3:
+          # CHANGE to your Hetzner Object Storage region: fsn1 / nbg1 / hel1
+          endpoint: fsn1.your-objectstorage.com
+          bucket_name: specht-labs-mimir-blocks
+          access_key_id: ${AWS_ACCESS_KEY_ID}
+          secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+    ingester:
+      ring:
+        replication_factor: 1
+    store_gateway:
+      sharding_ring:
+        replication_factor: 1
+    ingest_storage:
+      kafka:
+        auto_create_topic_default_partitions: 8

--- a/kustomize/bases/mimir/helm-values.yaml
+++ b/kustomize/bases/mimir/helm-values.yaml
@@ -64,8 +64,7 @@ mimir:
       storage:
         backend: s3
         s3:
-          # CHANGE to your Hetzner Object Storage region: fsn1 / nbg1 / hel1
-          endpoint: fsn1.your-objectstorage.com
+          endpoint: hel1.your-objectstorage.com
           bucket_name: specht-labs-mimir-blocks
           access_key_id: ${AWS_ACCESS_KEY_ID}
           secret_access_key: ${AWS_SECRET_ACCESS_KEY}

--- a/kustomize/bases/mimir/kustomization.yaml
+++ b/kustomize/bases/mimir/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: lgtm
+
+helmCharts:
+  - name: mimir-distributed
+    repo: https://grafana.github.io/helm-charts
+    version: 6.0.6
+    releaseName: mimir
+    namespace: lgtm
+    valuesFile: helm-values.yaml

--- a/kustomize/overlays/specht-labs-v2/mimir/httproutes.yaml
+++ b/kustomize/overlays/specht-labs-v2/mimir/httproutes.yaml
@@ -12,7 +12,7 @@ spec:
       namespace: envoy-gateway-system
       sectionName: http
   hostnames:
-    - homelab.mimir.k8s.specht-labs.de
+    - homelab-mimir.k8s.specht-labs.de
   rules:
     - filters:
         - type: RequestHeaderModifier
@@ -35,7 +35,7 @@ spec:
       namespace: envoy-gateway-system
       sectionName: http
   hostnames:
-    - hass.mimir.k8s.specht-labs.de
+    - hass-mimir.k8s.specht-labs.de
   rules:
     - filters:
         - type: RequestHeaderModifier
@@ -58,7 +58,7 @@ spec:
       namespace: envoy-gateway-system
       sectionName: http
   hostnames:
-    - hass-schiltach.mimir.k8s.specht-labs.de
+    - hass-schiltach-mimir.k8s.specht-labs.de
   rules:
     - filters:
         - type: RequestHeaderModifier

--- a/kustomize/overlays/specht-labs-v2/mimir/httproutes.yaml
+++ b/kustomize/overlays/specht-labs-v2/mimir/httproutes.yaml
@@ -1,0 +1,71 @@
+# One HTTPRoute per tenant on the tailnet-only Gateway. Each injects the tenant's
+# X-Scope-OrgID so clients (Pis, Home Assistant) need no custom-header config.
+# Route + backend (mimir-gateway) are both in lgtm, so no ReferenceGrant needed.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mimir-homelab
+  namespace: lgtm
+spec:
+  parentRefs:
+    - name: tailnet
+      namespace: envoy-gateway-system
+      sectionName: http
+  hostnames:
+    - homelab.mimir.k8s.specht-labs.de
+  rules:
+    - filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Scope-OrgID
+                value: homelab
+      backendRefs:
+        - name: mimir-gateway
+          port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mimir-hass
+  namespace: lgtm
+spec:
+  parentRefs:
+    - name: tailnet
+      namespace: envoy-gateway-system
+      sectionName: http
+  hostnames:
+    - hass.mimir.k8s.specht-labs.de
+  rules:
+    - filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Scope-OrgID
+                value: hass
+      backendRefs:
+        - name: mimir-gateway
+          port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mimir-hass-schiltach
+  namespace: lgtm
+spec:
+  parentRefs:
+    - name: tailnet
+      namespace: envoy-gateway-system
+      sectionName: http
+  hostnames:
+    - hass-schiltach.mimir.k8s.specht-labs.de
+  rules:
+    - filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Scope-OrgID
+                value: hass-schiltach
+      backendRefs:
+        - name: mimir-gateway
+          port: 80

--- a/kustomize/overlays/specht-labs-v2/mimir/kustomization.yaml
+++ b/kustomize/overlays/specht-labs-v2/mimir/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: lgtm
+
+resources:
+  - ../../../bases/mimir
+  - ./httproutes.yaml
+
+generators:
+  - ./secret-generator.yaml

--- a/kustomize/overlays/specht-labs-v2/mimir/mimir-objstore.secret.yaml
+++ b/kustomize/overlays/specht-labs-v2/mimir/mimir-objstore.secret.yaml
@@ -5,8 +5,8 @@ metadata:
     name: mimir-objstore
     namespace: lgtm
 stringData:
-    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:Nbjm9B4+ATQLXH6H/J9RaFwj5V1aX+K6M9GqPWydPQ==,iv:n1somqRO1jjeIAKVGbMztKztaxcKulE/KZig6xQ1qys=,tag:spIRrLLLdw5HsF/i2+A0fA==,type:str]
-    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:Eu0FT1WZk0F7ZNFuS1PBAPwkAKdo5pJC+LUClLG6aA==,iv:2cJrim4yvDukp3/cbMeR44XQrHB8WCARvmHdW0DI/YA=,tag:wFWwoH60UFoe0TPdXyNGSQ==,type:str]
+    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:/X6MVGPd6JXyB8Zk3nq57KjILtE=,iv:rf0udIUB18eOV7H2oiW84HrYWjn6yaRDn9v7xs43D8w=,tag:jna69PJH2/8LfaL0iORGZg==,type:str]
+    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:RAxh30WHkZGMod8QPwS0b1zxUyVNc6tBnCjhzt4SnghTuiCEmLzzzA==,iv:TMwLMMIplB5JKUeY8VHgr+r5qddgy15dcj6SqhksNfE=,tag:2l/vmUrgN4Yj9len3LnxLw==,type:str]
 sops:
     age:
         - recipient: age1r9chn8pl3d4msxktw457x3xz2l8p04pwuyd7pkgldkmkakras5ks7tfsyq
@@ -45,7 +45,7 @@ sops:
             U2E1SnJXbktYQWZLdEFjSWdEanRmbUEKMqCuDdf6XuGWnKEiITqsheESBnVS5P/T
             gGHAAfvR9zgpGKvcO2IjPdg57IARkukBd4OCnVZxQvdwULhioRxGDw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-10T09:30:55Z"
-    mac: ENC[AES256_GCM,data:yL1toeWCDty+VLw0XZgvIcZ1P1Yk+w3XPazJFk/fhtmBVsOHSNNTseFHTi0nZp52C41ohSxtAgXTcPiOMP18DtRjnM07QUkLEWreJ1LQy6vTdeEhbCK27BIyYTL7Mi5FzBGZeeWb2gRRviBrPWza3O0R2m6816BC+gQmEYH+JGI=,iv:BfTI/srNBP4mUKaZDXDSi6oNC4MK8lrQPSQAMIXJCz4=,tag:YCUnKlt+8Dt12kOZbv/bXg==,type:str]
+    lastmodified: "2026-06-10T09:41:21Z"
+    mac: ENC[AES256_GCM,data:1rglBCxx5cx7Yko5cvPKv1OsX5oXqtxmFyq0sdHthD8tornjuznUX/gur1zAulFZyTYA50q2Y73hOmLQSTx5N9sS9DRdIMAIQHUTfNU+fZcxghgLlfToH8jwDdMHeqm+tIvUp/LZf6MINtkk2jRz0EuIM4C877hAN8879wB76C0=,iv:7aKREtT7Kz/4D/m1Zg3j7Rdb0HR1vLSRQbxXJ/QtZ1s=,tag:ElWRDOBWPDemsSvJVkhMGw==,type:str]
     encrypted_regex: ^(data|stringData|spec|bot_token|chat_id|url|token|signing_key|account_id)$
     version: 3.12.2

--- a/kustomize/overlays/specht-labs-v2/mimir/mimir-objstore.secret.yaml
+++ b/kustomize/overlays/specht-labs-v2/mimir/mimir-objstore.secret.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+    name: mimir-objstore
+    namespace: lgtm
+stringData:
+    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:Nbjm9B4+ATQLXH6H/J9RaFwj5V1aX+K6M9GqPWydPQ==,iv:n1somqRO1jjeIAKVGbMztKztaxcKulE/KZig6xQ1qys=,tag:spIRrLLLdw5HsF/i2+A0fA==,type:str]
+    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:Eu0FT1WZk0F7ZNFuS1PBAPwkAKdo5pJC+LUClLG6aA==,iv:2cJrim4yvDukp3/cbMeR44XQrHB8WCARvmHdW0DI/YA=,tag:wFWwoH60UFoe0TPdXyNGSQ==,type:str]
+sops:
+    age:
+        - recipient: age1r9chn8pl3d4msxktw457x3xz2l8p04pwuyd7pkgldkmkakras5ks7tfsyq
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByNjgvZjE1blY0S2RtanQ5
+            bWt0S3NsZDVDcU4wVWhUWFJRQW93L0hzN2dJClY3Vm0wYjFBQWdZZUtkMC9WTE51
+            UXVNVDJvQmUvdGZkb25uc05jbkFyTUUKLS0tIGVjWkNrQVZDNjByT3FHdm83NXhV
+            WnpUSUlsZ3hYbFB5cWxhdlcxSHZ3WTgKvKie1jHB4Oy5c7UeqkVFQYNXkb8HeCeE
+            XbLne86ud+5v//Z6+vAf+INwE3yRcPeqrm++IBlC7F94C+hUcHAoSw==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age10hzpv26wext204acftvf2n8r6hmnnwxdpkngzaysllpwynccjvjsjvhq4z
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJOGIzTUh0K243WEhPd3RH
+            NUVNcDYycWFHQ0o0a3B4dGVpZ0N4aVlCb0RRCi9QTGNEZmNiUEhKVXI3dHZQdjdT
+            ZnR0M0VDVUlOVDNwYTBNcm9Vc1NiVU0KLS0tIFY5blQ4M1lxMEl1K2hZc3BzUFRx
+            K1dBQnk3ZFdSTTY4ZGJoQ2xodGZNWlkKS6lw5gynpX55SJ7Kn9+BBjspAo+9+9ky
+            1gwWxLMLFwW2qT7R+FOo68qu3WTuUgRt6Pd1Qm+nYNNIPG17ESha5Q==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1l4lhmkmvr4lype9x4dm3y9lxk2uekqwwj65mp4c36tnph6ytfakqesnats
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3cU15Y2p0aXU4bHp3OWRk
+            eXpBUWJFTUlRUDlhZm9XS21zcytaT0RMcHo0CmNWOVAreithMklaSERLWm0yRzVN
+            Tjg1cnlVVkNzK3ZySjBDMzBsRWZOaVEKLS0tIFdMa05seGNEdmd0TU05NG9jQkhZ
+            ZW4rMzlqcW55dHQyVE9QK1p6a21EQ1kKGSoTQ2HF7olTqRQ5MOCtFy8PckrfPE9r
+            DGE+YwP8P4POZiveHJk0l8lt0dAWHBRRr3Ox1rGGBozXzgLDWn660w==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age15cq50fx3zeeqg5aqh06s6p9zsew3yjlggx3mzchqea6763uup5jsaz9pu3
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJSFpmVmlYaWsvMlhudSs5
+            Z1IrMHpwVjA1WVYyMjgrQXlXZFZZdEF0SFdZCldlcXFMTGd4R3dHQkZRSFBtbFY5
+            QXBFeWRnbUNqbmsxT2MvZUF5NU9LZ0EKLS0tIDhwWFdFRHlRT2U4M1ZLdHR1Si82
+            U2E1SnJXbktYQWZLdEFjSWdEanRmbUEKMqCuDdf6XuGWnKEiITqsheESBnVS5P/T
+            gGHAAfvR9zgpGKvcO2IjPdg57IARkukBd4OCnVZxQvdwULhioRxGDw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-10T09:30:55Z"
+    mac: ENC[AES256_GCM,data:yL1toeWCDty+VLw0XZgvIcZ1P1Yk+w3XPazJFk/fhtmBVsOHSNNTseFHTi0nZp52C41ohSxtAgXTcPiOMP18DtRjnM07QUkLEWreJ1LQy6vTdeEhbCK27BIyYTL7Mi5FzBGZeeWb2gRRviBrPWza3O0R2m6816BC+gQmEYH+JGI=,iv:BfTI/srNBP4mUKaZDXDSi6oNC4MK8lrQPSQAMIXJCz4=,tag:YCUnKlt+8Dt12kOZbv/bXg==,type:str]
+    encrypted_regex: ^(data|stringData|spec|bot_token|chat_id|url|token|signing_key|account_id)$
+    version: 3.12.2

--- a/kustomize/overlays/specht-labs-v2/mimir/secret-generator.yaml
+++ b/kustomize/overlays/specht-labs-v2/mimir/secret-generator.yaml
@@ -1,0 +1,6 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: mimir-objstore-secrets
+files:
+  - ./mimir-objstore.secret.yaml


### PR DESCRIPTION
## Goal

Stand up a self-hosted, multi-tenant Grafana Mimir on specht-labs-v2 (namespace `lgtm`) so the Pi homelab and Home Assistant instances can remote-write metrics into durable Hetzner Object Storage, instead of running a TSDB on the Pis or paying Grafana Cloud for that data. Lands the LGTM ApplicationSet scaffold so Loki/Tempo/Grafana are a one-line add later.

**Hold this PR until the Grafana Cloud trial ends / the bucket exists.** It is a deliberately partial slice: everything except the real S3 credentials.

## What's here

- `kustomize/bases/mimir/` — `mimir-distributed` 6.0.6 (Mimir 3.0.4), right-sized to 1 replica per component, RF1, zone-aware off, alertmanager/ruler/minio/rollout-operator off. Kafka ingest-storage kept (the Mimir 3.0 chart default) as a single-node KRaft broker. Blocks go to Hetzner Object Storage via `common.storage.s3` with credentials injected by env expansion.
- `kustomize/overlays/specht-labs-v2/mimir/` — namespace `lgtm`, the SOPS-encrypted object-storage Secret, and three per-tenant HTTPRoutes.
- `argo-apps/specht-labs-v2/lgtm.yaml` — ApplicationSet, Mimir live, Loki/Tempo/Grafana commented.

## Multitenancy

Tenants are created implicitly on first write. The tailnet Gateway injects `X-Scope-OrgID` per hostname, so clients (Pis, Home Assistant) need no custom-header config:

| Tenant | Ingest host |
|---|---|
| `homelab` | `homelab-mimir.k8s.specht-labs.de` |
| `hass` | `hass-mimir.k8s.specht-labs.de` |
| `hass-schiltach` | `hass-schiltach-mimir.k8s.specht-labs.de` |

Each is an HTTPRoute on the existing `tailnet`/`http` Gateway, backend `mimir-gateway:80`, route and backend co-namespaced in `lgtm` (no ReferenceGrant).

## Status: complete, held for trial end

The Hetzner Object Storage bucket (`specht-labs-mimir-blocks`, region `hel1`) is created, and `mimir-objstore.secret.yaml` holds the real SOPS-encrypted credentials. The S3 endpoint is `hel1.your-objectstorage.com`. Nothing left to fill in; this is held only so it lands when the Grafana Cloud trial ends.

## Verification done

`kustomize build --enable-helm kustomize/bases/mimir` renders clean; asserted multitenancy on, RF1 (ingester + store-gateway), Kafka wired to `mimir-kafka.lgtm.svc`, partitions trimmed to 8, no minio/alertmanager/ruler, `mimir-objstore` secretRef on all 10 component pods, and the gateway Service is `mimir-gateway:80`. Ingest hostnames are single-label (`<tenant>-mimir.k8s.specht-labs.de`) so the existing `*.k8s.specht-labs.de` wildcard resolves them. A full code review over the branch came back approve-with-suggestions; the Copilot review caught a two-label hostname bug, now fixed.

## Notes

- Capacity is tight: 3x cx23 workers (~2 vCPU / 3.9Gi each) shared with argocd/cilium/envoy/alloy; Mimir+Kafka add ~1.8 vCPU / 3.6Gi of requests and ~30Gi of PVCs. If pods sit Pending after first sync, that's why. The post-sync check in the plan covers it.
- The per-tenant routes match host only (no path `matches`), so each hostname currently reaches both write and read for its tenant. Fine under the tailnet-trust model; if you ever want write-only ingest, add a `matches` on `/api/v1/push` (+ `/otlp/v1/metrics`).
- Trust model: Mimir does not authenticate `X-Scope-OrgID`; isolation rests on the tailnet-only LB plus the Gateway being the only header-setting path. Per-tenant auth is a later add.

Design: `docs/superpowers/specs/2026-06-10-self-hosted-mimir-lgtm-design.md`
Plan: `docs/superpowers/plans/2026-06-10-self-hosted-mimir-lgtm.md`
