### PR TITLE
fix(observability): clear Entity Graph red noise + repoint argocd OTLP

### DIFF
--- a/grafana/kg-suppressions/README.md
+++ b/grafana/kg-suppressions/README.md
@@ -1,0 +1,56 @@
+# Knowledge Graph alert suppressions
+
+Suppressions for Grafana Cloud **Asserts / Knowledge Graph** assertions — the signals that
+color the Entity Graph red — managed as code.
+
+Like SLOs (see [`../slos`](../slos)), KG suppressions are **not** Kubernetes resources: the
+grafana-operator has no CRD for them, so they are synced with `gcx` against the Knowledge
+Graph API rather than applied by ArgoCD.
+
+## What belongs here (and what does not)
+
+Only assertions that are **benign-by-design** or a **cascade of a signal already owned
+elsewhere** (an SLO or a health-target alert). Suppressing does **not** drop telemetry —
+metrics and traces keep flowing; only the graph-coloring assertion is disabled.
+
+Do **not** suppress a real, user-impacting failure. If page-serving breaks, that must show
+up via the [static-pages SLOs](../slos) and health alerts — not be hidden here.
+
+## Current suppressions
+
+| Suppression | Why it is noise |
+|-------------|-----------------|
+| `mimir-tenant-deletion-marker-404` | Compactor polls object storage for a deletion marker that doesn't exist; the expected 404 is miscounted as a span error. |
+| `tailscale-operator-saas-log-latency` | Latency anomaly shipping logs to `log.tailscale.com` (Tailscale SaaS) — external dependency, not a cluster fault. |
+| `argocd-repo-server-span-errors` / `-span-anomalies` | Internal gRPC/Redis mesh + (pending-fix) OTLP-export span errors on repo-server. |
+| `argocd-application-controller-span-errors` / `-span-anomalies` | Cascade of repo-server RPC failures on the application controller. |
+| `grafana-operator-grafanacloud-client-errors` | ~1 req/min client errors to the Grafana Cloud API; self-recovering. |
+| `static-pages-cdn-resets-and-4xx` | CDN keepalive resets (app falls back to direct B2 — SLO stays 100%) + bot 4xx. |
+| `envoy-gateway-static-pages-cascade` | Shared gateway is red only because it proxies to static-pages above. |
+
+## Sync
+
+```bash
+# Apply
+gcx kg suppressions create -f grafana/kg-suppressions/suppressions.yaml
+
+# Inspect live suppressions
+gcx kg suppressions list
+
+# Remove one
+gcx kg suppressions delete <name>
+```
+
+The Entity Graph reads `asserts:*` recording rules and `traces_*` series over a query
+lookback window, so old red state lingers for ~5–15 min after a suppression is applied
+before the graph fully stabilizes.
+
+## CI (optional)
+
+To make this true GitOps, run the sync from CI on merge to `main` (the runner needs a
+Grafana Cloud token with Knowledge Graph write access exported as the usual `gcx` auth
+env vars):
+
+```yaml
+- run: gcx kg suppressions create -f grafana/kg-suppressions/suppressions.yaml
+```

--- a/grafana/kg-suppressions/suppressions.yaml
+++ b/grafana/kg-suppressions/suppressions.yaml
@@ -1,0 +1,85 @@
+# Knowledge Graph (Asserts) alert suppressions — managed as code, synced via gcx.
+#
+# These silence Entity Graph assertions that are benign-by-design or are cascades of a
+# signal already covered elsewhere (SLOs / health-target alerts). They do NOT touch the
+# underlying telemetry — the metrics and traces still flow; only the graph-coloring
+# assertion is disabled. Each entry documents WHY it is noise.
+#
+# matchLabels is an exact AND-match over the listed assertion labels; unlisted labels are
+# ignored. Available labels include: alertname, service, job, asserts_error_type,
+# asserts_request_context, asserts_request_type, asserts_entity_type.
+#
+# Sync:  gcx kg suppressions create -f grafana/kg-suppressions/suppressions.yaml
+# List:  gcx kg suppressions list
+disabledAlertConfigs:
+  # mimir — the compactor polls object storage for a per-tenant deletion marker that does
+  # not exist; object storage answers 404, which is the expected "no deletion requested"
+  # result, but Beyla records the 404 as a span error. Pure false positive.
+  - name: mimir-tenant-deletion-marker-404
+    matchLabels:
+      alertname: ErrorRatioBreach
+      service: mimir
+      asserts_request_context: "HEAD /specht-labs-mimir-blocks/spechtlabs/markers/tenant-deletion-mark.json"
+
+  # tailscale operator — latency anomalies on shipping its own logs to Tailscale's SaaS
+  # (log.tailscale.com). External-dependency latency on a control-loop, not a cluster fault.
+  - name: tailscale-operator-saas-log-latency
+    matchLabels:
+      alertname: LatencyAverageAnomaly
+      service: operator
+      job: tailscale/operator
+
+  # argocd control plane (repo-server + application-controller) — the internal gRPC/Redis
+  # service mesh emits span_errors on manifest generation, Redis cache calls, repo-server
+  # RPCs, and (currently) the OTLP trace export to the v1 Tempo endpoint that the v2 argocd
+  # overlay repoints via GitOps. None are user-facing; argocd's real health is its sync/app
+  # status + metrics, not these spans. Suppress span_errors breaches + anomalies for both.
+  # NOTE: the OTLP-export breach is also a real misconfig being fixed in
+  # kustomize/overlays/specht-labs-v2/argocd — merging that PR removes the underlying error;
+  # this suppression only stops it (and the rest of the mesh noise) from coloring the graph.
+  - name: argocd-repo-server-span-errors
+    matchLabels:
+      alertname: ErrorRatioBreach
+      service: argocd-repo-server
+      asserts_error_type: span_errors
+  - name: argocd-repo-server-span-anomalies
+    matchLabels:
+      alertname: ErrorRatioAnomaly
+      service: argocd-repo-server
+  - name: argocd-application-controller-span-errors
+    matchLabels:
+      alertname: ErrorRatioBreach
+      service: argocd-application-controller
+      asserts_error_type: span_errors
+  - name: argocd-application-controller-span-anomalies
+    matchLabels:
+      alertname: ErrorRatioAnomaly
+      service: argocd-application-controller
+
+  # grafana-operator — occasional client errors talking to the Grafana Cloud API
+  # (spechtlabs.grafana.net) at ~1 req/min. Low-volume external API blips, self-recovering.
+  - name: grafana-operator-grafanacloud-client-errors
+    matchLabels:
+      alertname: ErrorRatioBreach
+      service: grafana-operator
+      asserts_error_type: client_errors
+
+  # static-pages — outbound calls to the Cloudflare CDN (cdn.specht-labs.de) hit connection
+  # resets (~220ms, HTTP keepalive churn); the app transparently retries / falls back to
+  # direct Backblaze B2, so page-serving availability stays 100% (see grafana/slos —
+  # Static Pages Proxy Availability). Also covers unauthenticated bot 4xx (/api/upload 403,
+  # 404s). Graph noise only; real user impact is owned by the proxy SLOs + health alerts.
+  # Follow-up (low priority, out of repo): expose IdleConnTimeout in the staticpages proxy
+  # so idle CDN connections close before Cloudflare resets them.
+  - name: static-pages-cdn-resets-and-4xx
+    matchLabels:
+      alertname: ErrorRatioBreach
+      service: static-pages
+
+  # envoy (shared gateway) — only red because it proxies to static-pages above; Grafana's
+  # own RCA suggestion on the entity confirms the cascade ("envoy has outbound calls to
+  # static-pages that has issues"). Suppress the inherited breach.
+  - name: envoy-gateway-static-pages-cascade
+    matchLabels:
+      alertname: ErrorRatioBreach
+      service: envoy

--- a/kustomize/overlays/specht-labs-v2/argocd/kustomization.yaml
+++ b/kustomize/overlays/specht-labs-v2/argocd/kustomization.yaml
@@ -80,3 +80,22 @@ patches:
               k8s.grafana.com/scrape: "true"
               k8s.grafana.com/metrics.portName: "metrics"
               k8s.grafana.com/job: "argocd-server"
+  # v2 telemetry: the shared base points ArgoCD's OTLP trace export at the v1 self-hosted
+  # Tempo (tempo-distributor.observability:4317), which does not exist on v2. Every ArgoCD
+  # component's trace export therefore fails ~100%, surfacing in the Knowledge Graph as a
+  # continuous ErrorRatioBreach on the outbound
+  # /opentelemetry.proto.collector.trace.v1.TraceService/Export call (repo-server et al.).
+  # Repoint to the cluster's Grafana Alloy receiver — the same OTLP destination the
+  # static-pages overlay uses — over plaintext gRPC (4317). Base stays unchanged for
+  # labk3s/specht-labs, which keep the self-hosted Tempo endpoint.
+  - target:
+      kind: ConfigMap
+      name: argocd-cmd-params-cm
+    patch: |
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: argocd-cmd-params-cm
+      data:
+        otlp.address: "grafana-k8s-monitoring-alloy-receiver.monitoring.svc.cluster.local:4317"
+        otlp.insecure: "true"


### PR DESCRIPTION
The Asserts Entity Graph showed almost everything red, but the cluster was healthy: the KG pipeline passes 11/11 and the red was OUTBOUND span-error assertions from a few non-user-impacting sources propagating along graph edges.

Two changes:

- argocd OTLP: the shared base points argocd's trace export at the v1 self-hosted Tempo (tempo-distributor.observability:4317), which does not exist on v2, so every argocd component's export fails ~100% and surfaces as a continuous ErrorRatioBreach on the TraceService/Export call. Repoint it on the v2 overlay to the cluster's Grafana Alloy receiver over plaintext gRPC, the same destination static-pages already uses. Base unchanged for labk3s/v1.

- KG suppressions as code: new grafana/kg-suppressions/ (synced via `gcx kg suppressions create`, mirroring the grafana/slos hybrid model) for assertions that are benign-by-design or cascades already owned by SLOs/health alerts: mimir tenant-deletion-marker 404, tailscale operator SaaS log latency, grafana-operator Grafana Cloud client errors, static-pages CDN keepalive resets + bot 4xx (app falls back to B2, proxy SLO stays 100%), the envoy cascade of static-pages, and the argocd control-plane internal gRPC/Redis span mesh. Telemetry is untouched; only the graph-coloring assertion is disabled.