### PR TITLE
fix(envoy-gateway): tag tailnet LB as o11y-endpoint

### DIFF
--- a/apps/envoy-gateway/cluster/specht-labs-v2/tailscale-envoyproxy.yaml
+++ b/apps/envoy-gateway/cluster/specht-labs-v2/tailscale-envoyproxy.yaml
@@ -12,7 +12,7 @@ spec:
         loadBalancerClass: tailscale
         annotations:
           tailscale.com/hostname: k8s
-          tailscale.com/tags: tag:core-infra
+          tailscale.com/tags: tag:core-infra,tag:o11y-endpoint
           # external-dns (source=service) publishes this wildcard for the tailnet Gateway.
           external-dns.alpha.kubernetes.io/hostname: "*.k8s.specht-labs.de"
           # Pin the targets to the k8s-load-balancer tailnet device's stable IPs. Required because
@@ -26,6 +26,6 @@ spec:
             metadata:
               annotations:
                 tailscale.com/hostname: k8s-load-balancer
-                tailscale.com/tags: tag:core-infra
+                tailscale.com/tags: tag:core-infra,tag:o11y-endpoint
             spec:
               loadBalancerClass: tailscale


### PR DESCRIPTION
## Goal

Let `tag:o11y-agent` devices (Home Assistant, and other agents) actually reach the v2 tailnet load balancer to ship metrics/logs/traces.

## Rationale

Home Assistant (`tag:o11y-agent`) was getting 100% packet loss to `k8s-load-balancer` (`100.74.67.24`), so its Alloy add-on buffered everything in the WAL with `context deadline exceeded`. The tailnet works otherwise (MagicDNS reachable), and nuc writes fine.

The cause is a tagging gap from the v2 consolidation. The old per-app tailscale ingresses (e.g. `apps/grafana-mimir/cluster/specht-labs/tailscale-ingress.yaml`) were tagged `tag:o11y-endpoint`, which the tailnet ACL grants `tag:o11y-agent` and `tag:o11y-collector` access to. The v2 setup moved all ingestion onto the shared envoy LB but tagged it only `tag:core-infra`. So:

- nuc reaches the LB only incidentally: it also carries `tag:core-infra`, covered by the `core-infra -> core-infra` grant.
- agents with just `tag:o11y-agent` have no grant to `tag:core-infra` (the ACL even has a test asserting o11y traffic should not use core-infra), so they are dropped.

## Changes

Add `tag:o11y-endpoint` alongside `tag:core-infra` on the LB (both the `envoyService` annotation and the StrategicMerge patch). The existing ACL grant then covers o11y agents and collectors. No ACL change is required; `tag:o11y-endpoint` ownership already includes `tag:k8s-operator`, so the operator may assign it.

## Notes

After this syncs and the tailscale operator updates the device tags, Home Assistant should connect and drain its WAL. Worth a follow-up on least privilege: the grant for `tag:o11y-endpoint` is all-ports (`ip: ["*"]`), and this LB is shared (also serves argocd/tka), so o11y agents gain L3 reach to the whole node. Scoping that grant to 80/443 would tighten it, but it is out of scope here.