### PR TITLE
fix(static-pages): extend API upload timeout

### DIFF
--- a/apps/static-pages/base/helm-values.yaml
+++ b/apps/static-pages/base/helm-values.yaml
@@ -61,6 +61,18 @@ staticpages:
     api:
       hostnames:
         - pages.specht-labs.de
+      # Envoy's default 15s request timeout is too short for multipart uploads.
+      # Keep this aligned with the nginx Ingress timeout used by the other overlay.
+      rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /api
+          timeouts:
+            request: 600s
+          backendRefs:
+            - name: static-pages-api
+              port: 8081
     proxy:
       hostnames:
         - specht-labs.de


### PR DESCRIPTION
## Summary

- configure a 600-second request timeout on the StaticPages API HTTPRoute
- preserve the existing /api match and static-pages-api backend when overriding the chart rule
- align Envoy Gateway behavior with the existing nginx Ingress upload timeout

## Context

The telegram-tui documentation upload reached Envoy Gateway but failed with HTTP 504 after the default 15-second request timeout:
https://github.com/SpechtLabs/telegram-tui/actions/runs/30660635211/job/91257935025

## Validation

- rendered apps/static-pages/cluster/specht-labs with Kustomize and Helm
- kubeconform: 11 resources, 9 valid, 0 invalid, 0 errors, 2 skipped
- verified the rendered static-pages-api HTTPRoute contains request: 600s